### PR TITLE
Add Sourcey

### DIFF
--- a/source/list.ts
+++ b/source/list.ts
@@ -1951,6 +1951,16 @@ const rawList: RawEntry[] = [
 		github: 'haldean/sortastatic',
 	},
 	{
+		name: 'Sourcey',
+		github: 'sourcey/sourcey',
+		website: 'https://sourcey.com',
+		is: 'static site generator',
+		language: 'TypeScript',
+		license: 'AGPL-3.0',
+		description:
+			'Open source documentation platform for OpenAPI specs and markdown.',
+	},
+	{
 		name: 'Speechhub',
 		github: 'pythonmg/speechhub',
 	},


### PR DESCRIPTION
Adds Sourcey — open source documentation platform that generates static sites from OpenAPI specs and markdown.

https://sourcey.com
https://github.com/sourcey/sourcey