### PR TITLE
Add DD Photos

### DIFF
--- a/source/list.ts
+++ b/source/list.ts
@@ -440,6 +440,11 @@ const rawList: RawEntry[] = [
 		website: 'https://daux.io',
 	},
 	{
+		name: 'DD Photos',
+		github: 'dougdonohoe/ddphotos',
+		is: 'static site generator',
+	},
+	{
 		name: 'deplate',
 		github: 'tomtom/deplate',
 	},


### PR DESCRIPTION
Adds [DD Photos](https://github.com/dougdonohoe/ddphotos) to the listing.

DD Photos is a static photo and video album generator: a Go CLI (`photogen`) resizes images to WebP,
transcodes video to browser-friendly MP4, and emits JSON index files, which a pre-built SvelteKit
frontend renders as a fully static site — no server code and no database. It powers
[ddphotos.donohoe.info](https://ddphotos.donohoe.info).

The entry is intentionally minimal — `license`, `website`, `language` and `description` are all
correct on the GitHub repository already, so per the `RawEntry` docs they are left for hydration to
fill in. Placed alphabetically between `Daux.io` and `deplate`.
