### PR TITLE
Add microfolio

### DIFF
--- a/source/list.ts
+++ b/source/list.ts
@@ -1298,6 +1298,11 @@ const rawList: RawEntry[] = [
 		license: 'BSD-2-Clause',
 	},
 	{
+		name: 'microfolio',
+		github: 'aker-dev/microfolio',
+		is: 'static site generator',
+	},
+	{
 		name: 'Middleman',
 		github: 'middleman/middleman',
 	},


### PR DESCRIPTION
Adds [microfolio](https://github.com/aker-dev/microfolio), a modern static portfolio generator built on SvelteKit 2 and Tailwind CSS 4, which just reached its 1.0 release.

It generates a fully static site from local markdown content, so it fits the `static site generator` category.

The entry is kept minimal since `github` is specified and GitHub's own metadata (license, website, language, description, dates) is accurate, as per the `RawEntry` documentation.