### PR TITLE
Bound the 429 retry so CI cannot hang for 6 hours

### DIFF
--- a/source/test.ts
+++ b/source/test.ts
@@ -51,23 +51,33 @@ export function halt(milliseconds: number) {
 	})
 }
 
+/** How many times to retry a URL that responds with 429, before giving up. */
+const retries = 3
+
 /**
  * Fetch a URL with automatic retry on 429 (rate limit) responses.
+ * Gives up after {@link retries} attempts and returns the 429 response, as some
+ * hosts rate limit CI runners indefinitely, which would otherwise retry forever.
  * @param url The URL to fetch
  * @param init The fetch options and configuration object for the request
+ * @param attempt Which attempt this is, starting at 1
  * @returns A promise that resolves to the fetch Response
  */
-export async function fetcher(url: string, init: unknown): Promise<Response> {
+export async function fetcher(
+	url: string,
+	init: unknown,
+	attempt: number = 1,
+): Promise<Response> {
 	try {
 		// @ts-expect-error RequestInit is not yet available to our types even though fetch is
 		const response = await fetch(url, init)
-		if (response.status === 429) {
+		if (response.status === 429 && attempt < retries) {
 			// wait a minute
 			console.warn(
-				`${url} returned 429, too many requests, trying again in a minute`,
+				`${url} returned 429, too many requests, trying again in a minute (attempt ${attempt} of ${retries})`,
 			)
 			await halt(60 * 1000)
-			return fetcher(url, init)
+			return fetcher(url, init, attempt + 1)
 		}
 		return response
 	} catch (error) {


### PR DESCRIPTION
## The problem

`fetcher()` in `source/test.ts` retries a 429 response once a minute, forever:

```ts
if (response.status === 429) {
	console.warn(`${url} returned 429, too many requests, trying again in a minute`)
	await halt(60 * 1000)
	return fetcher(url, init)   // no attempt limit
}
```

If a host returns 429 and never lets up, that call never returns and the job runs until GitHub cancels it at the 6 hour job limit.

That is what happened on master in [run 32633030239](https://github.com/bevry/staticsitegenerators/actions/runs/32633030239). `https://www.contentful.com` began returning 429 to the ubuntu runner at `10:10:57` and never stopped. The log shows **360 consecutive retries**, exactly one per minute, until the job was cancelled at `16:10`. Windows failed identically (`6h0m4s`). The macos runner was not affected and passed in 2 hours. Only that one URL ever returned 429 — the other ~1900 were fine.

## The fix

Give up after 3 attempts and return the 429 response.

`checkURL` already treats a non-ok response as a warning rather than a test failure, so nothing needs to change downstream: the worst case per URL goes from an unbounded hang to ~2 minutes and one warning line.

```
checkURL: https://www.contentful.com returned status 429 (expected 200)
```

## Verification

`tsc --noEmit`, `eslint`, and `prettier --check` all pass.

Behaviour confirmed against a local server that returns 429 unconditionally — the old code never returns, the new code does:

```
http://127.0.0.1:55316/ returned 429, too many requests, trying again in a minute (attempt 1 of 3)
http://127.0.0.1:55316/ returned 429, too many requests, trying again in a minute (attempt 2 of 3)
RESULT status=429 ok=false requests=3 elapsed=2.00min
```

## Note: contentful's 429 is not a rate limit

Worth recording, because it means backoff can never fix this particular URL. The response headers are:

```
HTTP/2 429
server: Vercel
x-vercel-mitigated: challenge
x-vercel-challenge-token: 2.1787769825.60.NzcwZWFjYTY2YTE3NzFhOThlYzcxNDk2...
```

`www.contentful.com` sits behind Vercel's bot challenge, which answers 429 to any client that cannot solve a browser JS challenge. It is "you are not a browser", not "you have made too many requests". I reproduced it from an ordinary residential connection, and the status is 429 regardless of method or user agent:

| request | status |
| --- | --- |
| GET, `User-Agent: node` | 429 |
| GET, no User-Agent | 429 |
| GET, descriptive project User-Agent | 429 |
| HEAD, descriptive project User-Agent | 429 |
| GET, real Chrome User-Agent | 429 |
| HEAD, real Chrome User-Agent | 429 |

So waiting longer, backing off further, sending a nicer User-Agent, or switching to HEAD all achieve nothing here. Bounding the retry is what stops the hang.

## Possible follow-ups

Out of scope for this PR:

- **Do not retry 429 at all.** A 429 proves the host is alive and answering, which is the only thing this suite checks — it is not link rot. Given the above, a retry mostly just burns wall clock. The same argument applies to a 403 from a bot wall. That would make the worst case instant rather than ~2 minutes.
- Honouring `Retry-After` would beat a blind 60 second wait for hosts that *are* genuinely rate limiting (contentful sends no such header).
- `checkURL`'s doc comment says it makes a HEAD request, but it issues a full GET. Aligning the two would cut a lot of transfer across ~1900 URLs, even though it would not have helped here.
- Since de670ed, `checkURL` routes every failure to `console.warn`, so the "uris are valid / still exist" suite can no longer fail the build. It is currently ~1900 network requests that produce warnings and nothing else — the retry loop was the only part of it that could still break CI, and it did. Worth deciding whether that suite should be able to fail again, or move to a scheduled run rather than every push and PR.
- `.github/workflows/bevry.yml` has no `timeout-minutes`, so any future hang costs the full 6 hours on every affected runner. I have left that file alone since it looks generated by boundation.
