### PR TITLE
Limit GitHub API concurrency when hydrating

### DIFF
--- a/source/test.ts
+++ b/source/test.ts
@@ -134,6 +134,11 @@ kava.suite('static site generators list', function (suite, test) {
 		})
 	})
 
+	// This suite requires every third-party repository and website in the listing
+	// to be reachable at the same moment, on every os in the matrix. A single
+	// transient outage anywhere fails the run, and because `publish` declares
+	// `needs: test`, it also blocks the deploy. Recent examples, each of which
+	// passed on the very next run: nestacms.com, hexo.io.
 	suite('uris are valid / still exist', function (suite, test) {
 		// @ts-expect-error kava isn't typed
 		this.setConfig({ concurrency: 50 }) // eslint-disable-line

--- a/source/test.ts
+++ b/source/test.ts
@@ -203,6 +203,20 @@ kava.suite('static site generators list', function (suite, test) {
 	})
 
 	suite('local render', function (suite, test) {
+		// Hydrating the listing costs 430 api requests, so running it on every os in
+		// the matrix costs 1290 a run against an hourly budget shared by every job
+		// and every run in the repository. Five runs in half an hour exhausted it
+		// and returned `API rate limit exceeded for installation`. The result is
+		// identical on every platform and only the publish job consumes it, so
+		// within ci this runs on linux alone, cutting a run to 430. Run locally, on
+		// any platform, it always runs.
+		if (process.env.CI && process.platform !== 'linux') {
+			console.warn(
+				`skipping local render on ${process.platform}, in ci it runs on linux alone to stay within the github api rate limit`,
+			)
+			return
+		}
+
 		let result: HydrateReturn
 
 		test('hydrate local data', function (done) {

--- a/source/test.ts
+++ b/source/test.ts
@@ -203,24 +203,25 @@ kava.suite('static site generators list', function (suite, test) {
 	})
 
 	suite('local render', function (suite, test) {
-		// Hydrating the listing costs 430 api requests, so running it on every os in
-		// the matrix costs 1290 a run against an hourly budget shared by every job
-		// and every run in the repository. Five runs in half an hour exhausted it
-		// and returned `API rate limit exceeded for installation`. The result is
-		// identical on every platform and only the publish job consumes it, so
-		// within ci this runs on linux alone, cutting a run to 430. Run locally, on
-		// any platform, it always runs.
-		if (process.env.CI && process.platform !== 'linux') {
+		// Enriching the listing costs 430 github api requests, so doing it on every
+		// os in the matrix costs 1290 a run against an hourly budget shared by every
+		// job and every run in the repository. Five runs in half an hour exhausted
+		// it and returned `API rate limit exceeded for installation`. The enriched
+		// result is identical on every platform, so within ci only linux fetches it,
+		// cutting a run to 430. Run locally it always fetches, whatever the platform.
+		// The suite still runs everywhere regardless, because it writes raw.json and
+		// hydrated.json, which `source/index.ts` imports and `our:verify` resolves.
+		const github = !process.env.CI || process.platform === 'linux'
+		if (!github) {
 			console.warn(
-				`skipping local render on ${process.platform}, in ci it runs on linux alone to stay within the github api rate limit`,
+				`skipping github enrichment on ${process.platform}, in ci only linux fetches it to stay within the api rate limit`,
 			)
-			return
 		}
 
 		let result: HydrateReturn
 
 		test('hydrate local data', function (done) {
-			hydrate(rawList, { log, corrective: true })
+			hydrate(rawList, { log, corrective: true, github })
 				.then(function (_result) {
 					ok(_result.raw, 'raw result was as expected')
 					ok(_result.hydrated, 'hydration result was as expected')

--- a/source/test.ts
+++ b/source/test.ts
@@ -26,12 +26,37 @@ const fetchOptions: unknown = {
 	redirect: 'error',
 }
 
+const oneSecond = 1000
+const thirySeconds = oneSecond * 30
+const oneMinute = oneSecond * 60
+
+/** This should be adapted based on what we learn on what a platform supports before it hits 429 issues. */
+const requestConcurrency = 40
+
 /**
- * How long a single request may run before it is aborted.
- * Without this a host that accepts the connection then stalls holds up the
- * entire run, as the built-in fetch has no overall deadline of its own.
+ * How long until a 429 is tried again.
+ * 429 requests are us requesting too many things at once, which may vary based on the platform.
+ * They will be retried indefinitely until a non-429 status is returned.
  */
-const requestTimeout = 30 * 1000
+const fetcherRetryDelay = oneMinute
+const fetcherRetryDelayHuman = 'one minute'
+
+/**
+ * How long until a timeout of a request occurs?
+ * Without this a host that accepts the connection this then stalls the suite concurrency, as the built-in fetch has no overall deadline of its own.
+ */
+const requestTimeout = thirySeconds
+
+/**
+ * How long to wait before the first retry of a failed request (timeout or non-429 failure status).
+ * For each retry, it is doubled.
+ * This should be twice the timeout, because if it struggled to respond in time of the timeout, it is unlikely it will respond in time to another request.
+ */
+const retryDelay = requestTimeout * 2
+
+/** How many times to retry a failured URL before failing tit */
+const retries = 3
+
 
 /**
  * Log a message with the specified log level. Debug level messages are filtered out.
@@ -49,7 +74,7 @@ function log(logLevel: string | number, ...args: unknown[]) {
  * @returns A promise that resolves after the specified delay
  */
 export function halt(milliseconds: number) {
-	if (milliseconds < 1000) {
+	if (milliseconds < oneSecond) {
 		console.warn(
 			'halt accepts milliseconds, you may have attempted to send it seconds, as you sent a value below 1000 milliseconds',
 		)
@@ -75,9 +100,9 @@ export async function fetcher(url: string, init: unknown): Promise<Response> {
 		if (response.status === 429) {
 			// wait a minute
 			console.warn(
-				`${url} returned 429, too many requests, trying again in 30 minutes`,
+				`${url} returned 429, too many requests, trying again in ${fetcherRetryDelayHuman}`,
 			)
-			await halt(1000 * 60 * 30)
+			await halt(fetcherRetryDelay)
 			return await fetcher(url, init)
 		}
 		return response
@@ -88,12 +113,6 @@ export async function fetcher(url: string, init: unknown): Promise<Response> {
 		return Promise.reject(error)
 	}
 }
-
-/** How many times to try a url again after the first attempt fails. */
-const retries = 3
-
-/** How long to wait before the first retry, doubling for each one after. */
-const retryDelay = 2000
 
 /**
  * Check if a URL is accessible by making a HEAD request through a status checking service.
@@ -106,6 +125,7 @@ const retryDelay = 2000
 async function checkURL(url: string) {
 	let lastError: unknown = null
 	let lastStatus: number | null = null
+	// this is a for loop, unlike fetcher there is no recursion here
 	for (let attempt = 0; attempt <= retries; attempt++) {
 		const started = Date.now()
 		try {
@@ -114,20 +134,25 @@ async function checkURL(url: string) {
 			// u.searchParams.set('url', url)
 			// const res = await fetcher(u.toString(), fetchOptions)
 			const res = await fetcher(url, fetchOptions)
-			if (res.ok) return
+			if (res.ok) return // success case, return
+			// request was succesful with failure status
 			lastError = null
 			lastStatus = res.status
 		} catch (err) {
+			// request was unsuccessful, no failure status
 			lastError = err
 			lastStatus = null
 		}
+		// inform the user of how long it took, and what our plan is
 		const seconds = ((Date.now() - started) / 1000).toFixed(1)
 		const reason = lastError ? String(lastError) : `status ${lastStatus}`
 		if (attempt === retries) {
+			// we've already done all the retries
 			console.warn(
 				`checkURL: ${url} failed after ${seconds}s (${reason}), giving up after ${retries} retries`,
 			)
 		} else {
+			// retry
 			const delay = retryDelay * 2 ** attempt
 			console.warn(
 				`checkURL: ${url} failed after ${seconds}s (${reason}), retrying in ${delay / 1000} seconds (retry ${attempt + 1} of ${retries})`,
@@ -135,6 +160,7 @@ async function checkURL(url: string) {
 			await halt(delay)
 		}
 	}
+	// if it was successful, the earlier `return` would have happened, so this is a failure case
 	if (lastError) return Promise.reject(lastError)
 	equal(
 		lastStatus,
@@ -182,7 +208,7 @@ kava.suite('static site generators list', function (suite, test) {
 	// hexo.io, psyke.org. `checkURL` now retries to absorb that.
 	suite('uris are valid / still exist', function (suite, test) {
 		// @ts-expect-error kava isn't typed
-		this.setConfig({ concurrency: 50 }) // eslint-disable-line
+		this.setConfig({ concurrency: requestConcurrency }) // eslint-disable-line
 		rawList.forEach(function ({ name, github, website, testWebsite }) {
 			if (github) {
 				const githubUrl = `https://github.com/${github}`

--- a/source/test.ts
+++ b/source/test.ts
@@ -207,6 +207,8 @@ kava.suite('static site generators list', function (suite, test) {
 			const p = spawnSync('npm', ['run', 'our:verify'], {
 				cwd: root,
 				stdio: 'inherit',
+				// npm is npm.cmd on windows, which spawnSync cannot resolve without a shell
+				shell: true,
 			})
 			// @ts-expect-error kava isn't typed
 			done(p.error || null)

--- a/source/test.ts
+++ b/source/test.ts
@@ -21,9 +21,17 @@ const rawSourcePath = join(root, 'source', 'list.ts')
 const hydratedPath = join(root, 'hydrated.json')
 
 const fetchOptions: unknown = {
-	// timeout: 30 * 1000,
+	// a `timeout` property here would do nothing, it is a node-fetch option that
+	// the built-in fetch ignores, see `requestTimeout` for what replaced it
 	redirect: 'error',
 }
+
+/**
+ * How long a single request may run before it is aborted.
+ * Without this a host that accepts the connection then stalls holds up the
+ * entire run, as the built-in fetch has no overall deadline of its own.
+ */
+const requestTimeout = 30 * 1000
 
 /**
  * Log a message with the specified log level. Debug level messages are filtered out.
@@ -59,8 +67,11 @@ export function halt(milliseconds: number) {
  */
 export async function fetcher(url: string, init: unknown): Promise<Response> {
 	try {
-		// @ts-expect-error RequestInit is not yet available to our types even though fetch is
-		const response = await fetch(url, init)
+		const response = await fetch(url, {
+			...(init as object),
+			// a fresh signal for each attempt, as a fired one cannot be reused
+			signal: AbortSignal.timeout(requestTimeout),
+		})
 		if (response.status === 429) {
 			// wait a minute
 			console.warn(
@@ -96,13 +107,7 @@ async function checkURL(url: string) {
 	let lastError: unknown = null
 	let lastStatus: number | null = null
 	for (let attempt = 0; attempt <= retries; attempt++) {
-		if (attempt) {
-			const delay = retryDelay * 2 ** (attempt - 1)
-			console.warn(
-				`checkURL: ${url} failed, retrying in ${delay / 1000} seconds (retry ${attempt} of ${retries})`,
-			)
-			await halt(delay)
-		}
+		const started = Date.now()
 		try {
 			// use a response that caches heavily <-- no longer exists and I cannot find a backup
 			// const u = new URL('https://status.bevry.workers.dev')
@@ -115,6 +120,19 @@ async function checkURL(url: string) {
 		} catch (err) {
 			lastError = err
 			lastStatus = null
+		}
+		const seconds = ((Date.now() - started) / 1000).toFixed(1)
+		const reason = lastError ? String(lastError) : `status ${lastStatus}`
+		if (attempt === retries) {
+			console.warn(
+				`checkURL: ${url} failed after ${seconds}s (${reason}), giving up after ${retries} retries`,
+			)
+		} else {
+			const delay = retryDelay * 2 ** attempt
+			console.warn(
+				`checkURL: ${url} failed after ${seconds}s (${reason}), retrying in ${delay / 1000} seconds (retry ${attempt + 1} of ${retries})`,
+			)
+			await halt(delay)
 		}
 	}
 	if (lastError) return Promise.reject(lastError)

--- a/source/test.ts
+++ b/source/test.ts
@@ -78,28 +78,51 @@ export async function fetcher(url: string, init: unknown): Promise<Response> {
 	}
 }
 
+/** How many times to try a url again after the first attempt fails. */
+const retries = 3
+
+/** How long to wait before the first retry, doubling for each one after. */
+const retryDelay = 2000
+
 /**
  * Check if a URL is accessible by making a HEAD request through a status checking service.
+ * Transient outages are common across the many third-party sites in the listing, so a
+ * failure is retried {@link retries} times, waiting 2, 4, then 8 seconds. Rate limiting
+ * is not handled here, {@link fetcher} deals with that.
  * @param url The URL to check for accessibility
  * @returns A promise that resolves if the URL is accessible, rejects if not
  */
 async function checkURL(url: string) {
-	try {
-		// use a response that caches heavily <-- no longer exists and I cannot find a backup
-		// const u = new URL('https://status.bevry.workers.dev')
-		// u.searchParams.set('url', url)
-		// const res = await fetcher(u.toString(), fetchOptions)
-		const res = await fetcher(url, fetchOptions)
-		if (!res.ok) {
-			equal(
-				res.status,
-				200,
-				`checkURL: response http status code should be 200 success on ${url}`,
+	let lastError: unknown = null
+	let lastStatus: number | null = null
+	for (let attempt = 0; attempt <= retries; attempt++) {
+		if (attempt) {
+			const delay = retryDelay * 2 ** (attempt - 1)
+			console.warn(
+				`checkURL: ${url} failed, retrying in ${delay / 1000} seconds (retry ${attempt} of ${retries})`,
 			)
+			await halt(delay)
 		}
-	} catch (err) {
-		return Promise.reject(err)
+		try {
+			// use a response that caches heavily <-- no longer exists and I cannot find a backup
+			// const u = new URL('https://status.bevry.workers.dev')
+			// u.searchParams.set('url', url)
+			// const res = await fetcher(u.toString(), fetchOptions)
+			const res = await fetcher(url, fetchOptions)
+			if (res.ok) return
+			lastError = null
+			lastStatus = res.status
+		} catch (err) {
+			lastError = err
+			lastStatus = null
+		}
 	}
+	if (lastError) return Promise.reject(lastError)
+	equal(
+		lastStatus,
+		200,
+		`checkURL: response http status code should be 200 success on ${url}`,
+	)
 }
 
 kava.suite('static site generators list', function (suite, test) {
@@ -135,10 +158,10 @@ kava.suite('static site generators list', function (suite, test) {
 	})
 
 	// This suite requires every third-party repository and website in the listing
-	// to be reachable at the same moment, on every os in the matrix. A single
-	// transient outage anywhere fails the run, and because `publish` declares
-	// `needs: test`, it also blocks the deploy. Recent examples, each of which
-	// passed on the very next run: nestacms.com, hexo.io.
+	// to be reachable, on every os in the matrix, and because `publish` declares
+	// `needs: test`, an outage anywhere also blocks the deploy. Three runs in a
+	// row failed on a different site that was not actually down: nestacms.com,
+	// hexo.io, psyke.org. `checkURL` now retries to absorb that.
 	suite('uris are valid / still exist', function (suite, test) {
 		// @ts-expect-error kava isn't typed
 		this.setConfig({ concurrency: 50 }) // eslint-disable-line

--- a/source/util.ts
+++ b/source/util.ts
@@ -60,6 +60,8 @@ export interface HydrateOptions {
 	log?: (logLevel: string, ...args: unknown[]) => void
 	/** How many GitHub API requests to have in flight at once */
 	concurrency?: number
+	/** Whether to enrich the entries with GitHub API data, defaults to true */
+	github?: boolean
 }
 
 /** The result of the hydrate operation containing both raw and hydrated data */
@@ -126,9 +128,12 @@ export async function hydrate(
 	// fresh spread of the options for every request, so `concurrency` alone gives
 	// each request its own pool and never limits the batch. GitHub responds to
 	// hundreds of simultaneous requests with a secondary rate limit.
-	const repos = await getGitHubRepositories(githubRepos, {
-		pool: new PromisePool(opts.concurrency),
-	})
+	const repos =
+		opts.github === false
+			? []
+			: await getGitHubRepositories(githubRepos, {
+					pool: new PromisePool(opts.concurrency),
+				})
 	for (const github of repos) {
 		// Prepare
 		const key = github.full_name.toLowerCase()

--- a/source/util.ts
+++ b/source/util.ts
@@ -3,7 +3,11 @@
 // Imports
 import { RawEntry, HydratedEntry } from './types.js'
 import naturalCompare from 'string-natural-compare'
-import { validateCredentials, getGitHubRepositories } from '@bevry/github-api'
+import {
+	validateCredentials,
+	getGitHubRepositories,
+	PromisePool,
+} from '@bevry/github-api'
 import arrangeKeys from 'arrangekeys'
 import crypto from 'node:crypto'
 
@@ -53,7 +57,9 @@ export interface HydrateOptions {
 	/** Cache duration in milliseconds */
 	cache?: number
 	/** Logging function that accepts a log level and arguments */
-	log?: (logLevel: string, ...args: unknown[]) => void  
+	log?: (logLevel: string, ...args: unknown[]) => void
+	/** How many GitHub API requests to have in flight at once */
+	concurrency?: number
 }
 
 /** The result of the hydrate operation containing both raw and hydrated data */
@@ -67,7 +73,7 @@ export interface HydrateReturn {
 /**
  * Trim redundant data from the listing and enhance with GitHub API data.
  * @param data An array of raw entries to hydrate with GitHub metadata
- * @param opts Configuration options for the hydration process including corrective mode, cache duration, and logging function
+ * @param opts Configuration options for the hydration process including corrective mode, cache duration, request concurrency, and logging function
  * @returns A promise resolving to both raw and hydrated entry arrays
  */
 export async function hydrate(
@@ -77,6 +83,7 @@ export async function hydrate(
 	validateCredentials()
 	if (opts.corrective == null) opts.corrective = false
 	if (opts.cache == null) opts.cache = 1000 * 60 * 60 * 24 // one day
+	if (opts.concurrency == null) opts.concurrency = 10
 
 	const rawMap: Record<string, RawEntry> = {}
 	const hydratedMap: Record<string, HydratedEntry> = {}
@@ -114,7 +121,14 @@ export async function hydrate(
 	}
 
 	// Enhance with github data
-	const repos = await getGitHubRepositories(githubRepos)
+	// Pass a single shared pool, rather than the `concurrency` option, as
+	// `queryREST` applies `opts.pool ??= new PromisePool(opts.concurrency)` to a
+	// fresh spread of the options for every request, so `concurrency` alone gives
+	// each request its own pool and never limits the batch. GitHub responds to
+	// hundreds of simultaneous requests with a secondary rate limit.
+	const repos = await getGitHubRepositories(githubRepos, {
+		pool: new PromisePool(opts.concurrency),
+	})
 	for (const github of repos) {
 		// Prepare
 		const key = github.full_name.toLowerCase()


### PR DESCRIPTION
**DRAFT** - hit rate limits - will resume in an hour

Fixes #472. Hydration was tripping GitHub's secondary rate limit because `getGitHubRepositories` fires all 430 repository requests at once.

Getting that to actually pass surfaced four further CI problems. Each is its own commit, so they can be taken or dropped independently.

## Limit GitHub API concurrency when hydrating

`hydrate()` called `getGitHubRepositories(githubRepos)` with no options, issuing all 430 requests simultaneously. Now passes a shared `PromisePool` capped at 10.

The `concurrency` option cannot be used for this, which is worth fixing upstream. `queryREST` does `opts.pool ??= new PromisePool(opts.concurrency)`, but `getGitHubRepository` calls it as `queryREST({ ...opts, pathname })` — a fresh spread per request — so each request builds its own pool and nothing limits the batch. Peak in-flight requests, measured with a stubbed fetch over the real listing:

| | peak concurrency |
| --- | --- |
| before | 430 |
| `{ concurrency: 10 }` | 430 |
| shared pool instance | 10 |

## Fix spawnSync on windows

`Error: spawnSync npm ENOENT` in the `auto-formatting our project again` test. npm is `npm.cmd` on windows, which `spawnSync` cannot resolve without a shell. Pre-existing, but unreachable until the render suite started completing.

## Retry url checks

Three runs in a row failed on a different third-party site, none of which was actually down: nestacms.com, hexo.io, psyke.org. A failed check is now retried 3 times, waiting 2, 4, then 8 seconds. Rate limiting is deliberately untouched — `fetcher` still owns that.

## Time out stalled requests

One run took 5m55s, effectively all of it a single url that hung for five minutes before failing; every other check had finished in seven seconds. `fetchOptions` carries a commented-out `timeout: 30 * 1000`, which would do nothing even if enabled, as it is a node-fetch option that the built-in fetch ignores:

```
fetch(url, { timeout: 3000 })                      still hanging at 8.0s
fetch(url, { signal: AbortSignal.timeout(3000) })  TimeoutError at 3.0s
```

Each attempt now gets `AbortSignal.timeout(30s)`, built inside `fetcher` so the 429 path gets a fresh one after its wait. Failures now also log why they failed and how long they took.

## Hydrate on one os in ci

430 requests across three operating systems is 1290 a run, against an hourly budget shared by every job and every run in the repository. Five runs in half an hour exhausted it and returned `API rate limit exceeded for installation`. The result is byte identical on every platform and only `publish` consumes it, so in ci this runs on linux alone. Run locally it always runs, so regenerating the json by hand is unaffected.

## Worth considering separately

Publishing is gated on every third-party url in the listing being reachable, on three operating systems, at the same moment. The retry and timeout make that far less likely to bite, but do not change its shape — restoring warn-only for `checkURL`, or moving the url suite to a schedule, would decouple link rot from deploys.

@balupton — the "date last fetched" caching you mentioned would compose well with the concurrency fix. Conditional requests would achieve it with less bookkeeping, since a 304 does not count against the rate limit.
