### PR TITLE
Only fetch the github data on one os in ci

### DIFF
--- a/source/test.ts
+++ b/source/test.ts
@@ -232,10 +232,25 @@ kava.suite('static site generators list', function (suite, test) {
 	})
 
 	suite('local render', function (suite, test) {
+		// Enriching the listing costs one github api request per repository, which
+		// on every os in the matrix triples the spend against an hourly budget that
+		// is shared by every job and every run in the repository. The enriched result
+		// is identical on every platform, so within ci only linux fetches it. Run
+		// locally it always fetches, whatever the platform.
+		//
+		// The suite itself still runs everywhere, because it writes raw.json and
+		// hydrated.json, which `source/index.ts` imports and `our:verify` resolves.
+		const github = !process.env.CI || process.platform === 'linux'
+		if (!github) {
+			console.warn(
+				`skipping github enrichment on ${process.platform}, in ci only linux fetches it to stay within the api rate limit`,
+			)
+		}
+
 		let result: HydrateReturn
 
 		test('hydrate local data', function (done) {
-			hydrate(rawList, { log, corrective: true })
+			hydrate(rawList, { log, corrective: true, github })
 				.then(function (_result) {
 					ok(_result.raw, 'raw result was as expected')
 					ok(_result.hydrated, 'hydration result was as expected')

--- a/source/util.ts
+++ b/source/util.ts
@@ -58,6 +58,8 @@ export interface HydrateOptions {
 	cache?: number
 	/** Logging function that accepts a log level and arguments */
 	log?: (logLevel: string, ...args: unknown[]) => void
+	/** Whether to enrich the entries with GitHub API data, defaults to true */
+	github?: boolean
 }
 
 /** The result of the hydrate operation containing both raw and hydrated data */
@@ -118,21 +120,26 @@ export async function hydrate(
 	}
 
 	// Enhance with github data
-	const repos = await getGitHubRepositories(githubRepos, {
-		// Pass a single shared PromisePool to limit concurrent requests.
-		//
-		// Limited to 100 as that is the GitHub API concurrency limit:
-		// > Make too many concurrent requests. No more than 100 concurrent requests are allowed. This limit is shared across the REST API and GraphQL API.
-		// > https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10#about-secondary-rate-limits
-		//
-		// Note that the `concurrency` option cannot be used for this. queryREST does
-		// `opts.pool ??= new PromisePool(opts.concurrency)`, but getGitHubRepository
-		// calls it as `queryREST({ ...opts, pathname })`, so the assignment lands on a
-		// fresh spread of the options for every request. Each request therefore builds
-		// its own pool and nothing limits the batch. Passing an already constructed
-		// pool works because the same instance is threaded through untouched.
-		pool: new PromisePool(100),
-	})
+	// Skipped entirely when `github` is false, so the entries are still assembled
+	// and returned, just without the github fields, at the cost of no api requests.
+	const repos =
+		opts.github === false
+			? []
+			: await getGitHubRepositories(githubRepos, {
+					// Pass a single shared PromisePool to limit concurrent requests.
+					//
+					// Limited to 100 as that is the GitHub API concurrency limit:
+					// > Make too many concurrent requests. No more than 100 concurrent requests are allowed. This limit is shared across the REST API and GraphQL API.
+					// > https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10#about-secondary-rate-limits
+					//
+					// Note that the `concurrency` option cannot be used for this. queryREST does
+					// `opts.pool ??= new PromisePool(opts.concurrency)`, but getGitHubRepository
+					// calls it as `queryREST({ ...opts, pathname })`, so the assignment lands on a
+					// fresh spread of the options for every request. Each request therefore builds
+					// its own pool and nothing limits the batch. Passing an already constructed
+					// pool works because the same instance is threaded through untouched.
+					pool: new PromisePool(100),
+				})
 	for (const github of repos) {
 		// Prepare
 		const key = github.full_name.toLowerCase()


### PR DESCRIPTION
Follow-up to #497, which was closed after the other fixes were cherry-picked. This is the one that was not taken, rebased onto current master and reduced to a single commit.

## The problem

Enriching the listing costs one github api request per repository. Doing that on all three operating systems triples the total spend, against an hourly budget shared by every job and every run in the repository:

```
Error: API rate limit exceeded for installation.
Request to https://api.github.com/repos/abakan-zz/ablog failed with status 403: Forbidden
```

The `pool: new PromisePool(100)` added in 95753b7 caps how many requests are in flight at once, which is the *concurrency* ceiling. This is the *hourly quota*, a separate limit — the pool does not reduce how many requests are made in total.

## The change

The enriched result is identical on every platform, so within ci only linux fetches it. Run locally it always fetches, whatever the platform, so regenerating the listing by hand is unaffected.

The suite still runs everywhere, because it writes `raw.json` and `hydrated.json`, which `source/index.ts` imports and `our:verify` resolves. Skipping the whole suite off linux instead fails with:

```
error  Can't resolve '../hydrated.json'
error  Can't resolve '../raw.json'
```

So this adds a `github` option to `hydrate` that skips only the api calls; the entries are still assembled and written, without the github fields.

Verified against the real listing with a stubbed fetch:

| | api requests | entries |
| --- | --- | --- |
| `hydrate(list, { github: false })` | 0 | 478, ids intact |
| `hydrate(list, {})` | 430 | 478 |
| ci on darwin | 0 | writes both json files |

## Why this may unblock the site

https://staticsitegenerators.bevry.me/ currently returns:

```
SyntaxError: Unexpected token 'N', "Not found:"... is not valid JSON
```

The worker fetches the listing from the npm cdn and gets a plain text 404 back, then parses it as json — the `'N'` is the first character of `Not found: /staticsitegenerators@4.0.1/hydrated.json`. Unpacking the published tarballs shows why:

| version | `raw.json` + `hydrated.json` |
| --- | --- |
| 4.0.0 | present, cdn serves them |
| 4.0.1 | absent |

Which is #498, and 7d855f3 is the right fix for it. But `publish` declares `needs: test`, so it only runs when all three test jobs pass — and the run for 7d855f3 failed on windows with the rate limit above, so `publish` was skipped and the packaging fix has not shipped.

This PR does not fix the site directly. It removes the thing that has been intermittently failing a job and therefore skipping `publish`, so 7d855f3 gets a chance to run. Cutting the per-run spend by two thirds should make that considerably more reliable.

If the site needs restoring before that lands, pinning the worker to `4.0.0` would do it immediately, since that version still has the files on the cdn.
